### PR TITLE
added interface override from command line

### DIFF
--- a/ecmean.py
+++ b/ecmean.py
@@ -34,7 +34,8 @@ class Diagnostic():
         if self.year1 == self.year2:  # Ignore if only one year requested
             self.ftrend = False
         #  These are here in prevision of future expansion to CMOR
-        self.interface = cfg['interface']
+        if not self.interface:
+            self.interface = cfg['interface']
         self.frequency = '*mon'
         self.ensemble = getattr(args, 'ensemble', 'r1i1p1f1')
         self.grid = '*'

--- a/global_mean.py
+++ b/global_mean.py
@@ -231,6 +231,8 @@ if __name__ == "__main__":
                         help='variant label (ripf number for cmor)')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='activate cdo debugging')
+    parser.add_argument('-i', '--interface', type=str, default='',
+                        help='interface (overrides config.yml)')
 
     args = parser.parse_args()
 

--- a/performance_indices.py
+++ b/performance_indices.py
@@ -270,6 +270,8 @@ if __name__ == '__main__':
                         help='variant label (ripf number for cmor)')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='activate cdo debugging')
+    parser.add_argument('-i', '--interface', type=str, default='',
+                        help='interface (overrides config.yml)')
     args = parser.parse_args()
 
     # log level with logging


### PR DESCRIPTION
Minor fast PR to implement a small change which I had forgotten in the cmor branch (the ability to select the interface (eg. EC-Earth4, CMIP5, CMIP6) from the command line)