### PR TITLE
Allow `xesmf>0.8` and refactor the tests 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-concurrency = multiprocessing

--- a/.github/workflows/mambatest.yml
+++ b/.github/workflows/mambatest.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         #python-version: ["3.11"]
     defaults:
       run:

--- a/.github/workflows/pypitest.yml
+++ b/.github/workflows/pypitest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         #python-version: ["3.10"]
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased is the current development version, which is currently lying in `main` branch.
 
+- Remove support for python 3.8
+- Refactor tests so that comparison is element-wise and not file-wise (Allow xesmf>0.8 and refactor the tests #93)
 - Simple support for allow running the code on MacOS and pinning of xesmf<0.8 to avoid code slowdown (support for macos #86)
 - Matplotlib pinning for solve temporary seaborn bug (Various updates and fixing the issue of matplotlib #89)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased is the current development version, which is currently lying in `main` branch.
 
+## [v0.1.6]
+
 - Remove support for python 3.8
 - Refactor tests so that comparison is element-wise and not file-wise (Allow xesmf>0.8 and refactor the tests #93)
 - Simple support for allow running the code on MacOS and pinning of xesmf<0.8 to avoid code slowdown (support for macos #86)

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -7,7 +7,7 @@ name : dev-ecmean
 channels:
   - conda-forge
 dependencies:
-  - python=>3.8
+  - python=>3.9
   - libnetcdf
   - xesmf
   - eccodes

--- a/docs/sphinx/source/installation.rst
+++ b/docs/sphinx/source/installation.rst
@@ -19,7 +19,7 @@ You can create a conda/mamba environment which incudes the python, `eccodes <htt
 However, you should start by cloning the repository from GitHub ::
 
     > git clone https://github.com/oloapinivad/ECmean4.git
-    > mamba create -n ecmean "python>=3.8" xesmf eccodes
+    > mamba create -n ecmean "python>=3.9" xesmf eccodes
     > mamba activate ecmean
     > pip install ECmean4
 
@@ -74,7 +74,7 @@ The required packages are listed in ``environment.yml`` and in ``pyproject.toml`
 A secondary environment available in  ``dev-environment.yml`` can be used for development, including testing capabilities and jupyter notebooks. 
 
 .. warning::
-	Python >=3.8 is requested
+	Python >=3.9 is requested
 
 
 

--- a/docs/sphinx/source/installation.rst
+++ b/docs/sphinx/source/installation.rst
@@ -10,19 +10,17 @@ Using PyPi
 
 .. warning::
 
-	Please note that although ECmean4 is distributed via PyPi, it depends on packages that currently are available only on conda-forge and 
-    on configuration files available from the GitHub repository. Therefore, the installation via pip requires the creation of a conda environment as well as the clone from the repository.
+	Please note that although ECmean4 is distributed via PyPi, it depends on packages that currently are available only on conda-forge and on configuration files available from the GitHub repository. Therefore, the installation via pip requires the creation of a conda environment as well as the clone from the repository.
 
 
 It will bring you the last version available on PyPi.
 You can create a conda/mamba environment which incudes the python, `eccodes <https://github.com/ecmwf/eccodes-python>`_ and `xESMF <https://xesmf.readthedocs.io/en/latest/>`_ dependencies, and then install ECmean4.
-However, you should start by cloning the repository from GitHub ::
+However, you should start by cloning the repository from GitHub, since the configuration files used for running ECmean4 are placed there ::
 
     > git clone https://github.com/oloapinivad/ECmean4.git
     > mamba create -n ecmean "python>=3.9" xesmf eccodes
     > mamba activate ecmean
     > pip install ECmean4
-
 
 
 Using GitHub
@@ -65,7 +63,7 @@ You can test by running in shell command line and you should and output as::
 
 You can also run tests by simply calling ``pytest`` - as long as you have the corresponding Python package installed - from the ECmean4 folder ::
 
-    > pytest
+    > python -m pytest
 
 Requirements
 ------------
@@ -73,8 +71,8 @@ Requirements
 The required packages are listed in ``environment.yml`` and in ``pyproject.toml``.
 A secondary environment available in  ``dev-environment.yml`` can be used for development, including testing capabilities and jupyter notebooks. 
 
-.. warning::
-	Python >=3.9 is requested
+.. note::
+	Both Unix and MacOS are supported. Python >=3.9 is requested.
 
 
 

--- a/ecmean/__init__.py
+++ b/ecmean/__init__.py
@@ -1,6 +1,6 @@
 """ECmean4 module"""
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 # functions to be accessible everywhere
 from ecmean.libs.diagnostic import Diagnostic

--- a/ecmean/libs/general.py
+++ b/ecmean/libs/general.py
@@ -247,9 +247,12 @@ def are_dicts_equal(dict1, dict2, tolerance=1e-6):
             if not are_dicts_equal(dict1[key], dict2[key], tolerance):
                 return False
         return True
-    elif isinstance(dict1, (int, float)) and isinstance(dict2, (int, float)):
-        if math.isnan(dict1) and math.isnan(dict2):
-            return True
-        return math.isclose(dict1, dict2, rel_tol=tolerance)
     else:
-        return dict1 == dict2
+        try:
+            dict1 = float(dict1)
+            dict2 = float(dict2)
+            if math.isnan(dict1) and math.isnan(dict2):
+                return True
+            return math.isclose(dict1, dict2, rel_tol=tolerance)
+        except ValueError:
+            return dict1 == dict2

--- a/ecmean/libs/general.py
+++ b/ecmean/libs/general.py
@@ -6,6 +6,7 @@ Shared functions for XArray ECmean4
 import os
 import logging
 import platform
+import math
 import multiprocessing
 import pandas as pd
 import numpy as np
@@ -228,3 +229,27 @@ def init_mydict(one, two):
             dd[o][t] = float('NaN')
 
     return dd
+
+
+def are_dicts_equal(dict1, dict2, tolerance=1e-6):
+    """
+    Recursively compare two dictionaries with a given tolerance for float comparisons.
+    To be used for testing purposes
+    """
+    if isinstance(dict1, dict) and isinstance(dict2, dict):
+        keys1 = set(dict1.keys())
+        keys2 = set(dict2.keys())
+
+        if keys1 != keys2:
+            return False
+
+        for key in keys1:
+            if not are_dicts_equal(dict1[key], dict2[key], tolerance):
+                return False
+        return True
+    elif isinstance(dict1, (int, float)) and isinstance(dict2, (int, float)):
+        if math.isnan(dict1) and math.isnan(dict2):
+            return True
+        return math.isclose(dict1, dict2, rel_tol=tolerance)
+    else:
+        return dict1 == dict2

--- a/ecmean/libs/support.py
+++ b/ecmean/libs/support.py
@@ -8,6 +8,8 @@ from glob import glob
 import logging
 import xarray as xr
 import xesmf as xe
+import sys
+from time import time
 import numpy as np
 from ecmean.libs.ncfixers import xr_preproc
 from ecmean.libs.files import inifiles_priority
@@ -127,6 +129,15 @@ class Supporter():
             if self.atmfix:
                 mask = self.atmfix(mask, keep_attrs=True)
             mask = self.atmremap(mask, keep_attrs=True)
+
+        tic = time()
+        mask = mask.load()
+        print(mask.mean().values)
+        toc = time()
+        loggy.warning('Running with xesmf version %s', xe.__version__)
+        loggy.warning('Mask computation in {:.4f} seconds'.format(toc - tic))
+        
+        sys.exit()
 
         return mask
 

--- a/ecmean/libs/support.py
+++ b/ecmean/libs/support.py
@@ -31,6 +31,8 @@ class Supporter():
         """Class for masks, areas and interpolation (xESMF-based)
         for both atmospheric and oceanic component"""
 
+        loggy.info('Running with xesmf version %s', xe.__version__)
+
         # define the basics
         self.atmareafile = inifiles_priority(atmdict)
         self.oceareafile = inifiles_priority(ocedict)
@@ -51,7 +53,7 @@ class Supporter():
         # loading and examining atmospheric file
         self.atmfield = self.load_area_field(self.atmareafile, comp='atm')
         self.atmgridtype = identify_grid(self.atmfield)
-        loggy.warning('Atmosphere grid is is a %s grid!', self.atmgridtype)
+        loggy.info('Atmosphere grid is is a %s grid!', self.atmgridtype)
 
         # compute atmopheric area
         if areas:
@@ -68,7 +70,7 @@ class Supporter():
         if self.oceareafile:
             self.ocefield = self.load_area_field(self.oceareafile, comp='oce')
             self.ocegridtype = identify_grid(self.ocefield)
-            loggy.warning('Oceanic grid is is a %s grid!', self.ocegridtype)
+            loggy.info('Oceanic grid is is a %s grid!', self.ocegridtype)
 
             # compute oceanic area
             if areas:
@@ -123,21 +125,15 @@ class Supporter():
 
         else:
             raise KeyError("ERROR: make_atm_masks -> Atmospheric component not supported!")
-
+        
+        # loading the mask to avoid issues with xesmf
+        mask = mask.load()
+    
         # interp the mask if required
         if self.atmremap is not None:
             if self.atmfix:
                 mask = self.atmfix(mask, keep_attrs=True)
             mask = self.atmremap(mask, keep_attrs=True)
-
-        tic = time()
-        mask = mask.load()
-        print(mask.mean().values)
-        toc = time()
-        loggy.warning('Running with xesmf version %s', xe.__version__)
-        loggy.warning('Mask computation in {:.4f} seconds'.format(toc - tic))
-        
-        sys.exit()
 
         return mask
 
@@ -161,6 +157,9 @@ class Supporter():
 
         else:
             raise KeyError("ERROR: make_oce_masks -> Oceanic component not supported!")
+        
+        # load mask to avoid issue with xesmf
+        mask = mask.load()
 
         # interp the mask if required
         if self.oceremap is not None:

--- a/ecmean/performance_indices.py
+++ b/ecmean/performance_indices.py
@@ -297,7 +297,7 @@ def performance_indices(exp, year1, year2,
   
     # loop on the variables, create the parallel process
     for varlist in weight_split(diag.field_all, diag.numproc):
-        print(varlist)
+        #print(varlist)
 
 
         core = Process(

--- a/ecmean/performance_indices.py
+++ b/ecmean/performance_indices.py
@@ -183,7 +183,7 @@ def pi_worker(util, piclim, face, diag, field_3d, varstat, varlist):
 
                     # horizontal averaging with land-sea mask
                     else:
-
+                        
                         complete = (final - cfield)**2 / vfield
                         outarray = mask_field(xfield=complete,
                                             mask_type=piclim[var]['mask'],
@@ -193,12 +193,11 @@ def pi_worker(util, piclim, face, diag, field_3d, varstat, varlist):
                     for region in diag.regions:
 
                         slicearray = select_region(outarray, region)
-
+ 
                         # latitude-based averaging
                         weights = np.cos(np.deg2rad(slicearray.lat))
                         out = slicearray.weighted(weights).mean().data
-
-                        # store the PI
+                         # store the PI
                         result[season][region] = round(float(out), 3)
 
                         # diagnostic

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ name : ecmean
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - libnetcdf
-  - xesmf<0.8
+  - xesmf
   - eccodes
   - esmpy
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "ECmean4 Global Climate Model lightweight evaluation tool"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,7 @@ performance_indices = "ecmean.performance_indices:pi_entry_point"
 
 [tool.setuptools.dynamic]
 version = {attr = "ecmean.__version__"}
+
+[tool.coverage.run]
+concurrency = ["multiprocessing"]
+

--- a/tests/test_global_mean.py
+++ b/tests/test_global_mean.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-import yaml
 import xarray as xr
 from ecmean.global_mean import global_mean
 from ecmean.libs.ncfixers import xr_preproc

--- a/tests/test_global_mean.py
+++ b/tests/test_global_mean.py
@@ -2,53 +2,99 @@
 
 import os
 import subprocess
-#import pytest
-from filecmp import cmp
+import yaml
 import xarray as xr
 from ecmean.global_mean import global_mean
 from ecmean.libs.ncfixers import xr_preproc
-#from ecmean.libs.general import set_multiprocessing_start_method
+from ecmean.libs.general import are_dicts_equal
+
+# set tolerance
+tolerance = 1e-3
 
 # set up coverage env var
 env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
 
-#@pytest.fixture(scope="session", autouse=True)
-#def always_spawn():
-#    set_multiprocessing_start_method()
+# Open the text file for reading
+def load_gm_txt_files(textfile):
+    """
+    Function to the read the global mean text files and extract the model values 
+    in order to create a dictionary that can be used for comparison
+    """
+
+    data_dict = {}
+    with open(textfile, 'r') as file:
+        # Read the file line by line
+        for line in file:
+            # Remove leading and trailing whitespace and split the line by '|'
+            columns = line.strip().split('|')
+            
+            # Check if there are at least 5 columns (including the header row)
+            if len(columns) >= 5:
+                # Extract the first and fourth columns and remove leading/trailing whitespace
+                variable = columns[1].strip()
+                value = columns[4].strip()
+                
+                # Add the data to the dictionary if it's not empty
+                if variable and value:
+                    data_dict[variable] = value
+    return data_dict
 
 # call on coupled ECE using parser and debug mode
 def test_cmd_global_mean_coupled():
-    thefile = 'tests/table/global_mean_cpld_EC-Earth4_r1i1p1f1_1990_1990.txt'
-    if os.path.isfile(thefile):
-        os.remove(thefile)
+    file1 = 'tests/table/global_mean_cpld_EC-Earth4_r1i1p1f1_1990_1990.txt'
+    file2 = 'tests/table/global_mean_cpld_1990_1990.ref'
+    if os.path.isfile(file1):
+        os.remove(file1)
     subprocess.run(['global_mean', 'cpld', '1990', '1990', '-j', '2',
                     '-c', 'tests/config.yml', '-t', '-v', 'debug'],
                     env=env, check=True)
-    assert cmp(thefile, 'tests/table/global_mean_cpld_1990_1990.ref')
+    
+    data1 = load_gm_txt_files(file1)
+    data2 = load_gm_txt_files(file2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+
 
 # call on amip ECE
 def test_global_mean_amip():
-    thefile = 'tests/table/global_mean_amip_EC-Earth4_r1i1p1f1_1990_1990.txt'
-    if os.path.isfile(thefile):
-        os.remove(thefile)
+    file1 = 'tests/table/global_mean_amip_EC-Earth4_r1i1p1f1_1990_1990.txt'
+    file2 = 'tests/table/global_mean_amip_1990_1990.ref'
+    if os.path.isfile(file1):
+        os.remove(file1)
     global_mean(exp='amip', year1=1990, year2=1990, numproc=1, config='tests/config.yml',
                 line=True)
-    assert cmp(thefile, 'tests/table/global_mean_amip_1990_1990.ref')
+    
+    data1 = load_gm_txt_files(file1)
+    data2 = load_gm_txt_files(file2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
 
 # call on amip ECE using the xdataset option
 def test_global_mean_amip_xdataset():
-    thefile = 'tests/table/global_mean_amip_EC-Earth4_r1i1p1f1_1990_1990.txt'
-    if os.path.isfile(thefile):
-        os.remove(thefile)
+    file1 = 'tests/table/global_mean_amip_EC-Earth4_r1i1p1f1_1990_1990.txt'
+    file2 = 'tests/table/global_mean_amip_1990_1990.ref'
+    if os.path.isfile(file1):
+        os.remove(file1)
     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
     global_mean(exp='amip', year1=1990, year2=1990, numproc=4, config='tests/config.yml',
                 xdataset=xfield)
-    assert cmp(thefile, 'tests/table/global_mean_amip_1990_1990.ref')
+    
+    data1 = load_gm_txt_files(file1)
+    data2 = load_gm_txt_files(file2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+
 
 # call on historical CMIP6
 def test_global_mean_CMIP6():
-    thefile = 'tests/table/global_mean_historical_EC-Earth3_r1i1p1f1_1990_1991.txt'
-    if os.path.isfile(thefile):
-        os.remove(thefile)
+    file1 = 'tests/table/global_mean_historical_EC-Earth3_r1i1p1f1_1990_1991.txt'
+    file2 = 'tests/table/global_mean_CMIP6_1990_1991.ref'
+    if os.path.isfile(file1):
+        os.remove(file1)
     global_mean(exp='historical', year1=1990, year2=1991, numproc=2, config='tests/config_CMIP6.yml', trend=True)
-    assert cmp(thefile, 'tests/table/global_mean_CMIP6_1990_1991.ref')
+
+    data1 = load_gm_txt_files(file1)
+    data2 = load_gm_txt_files(file2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+

--- a/tests/test_global_mean.py
+++ b/tests/test_global_mean.py
@@ -8,8 +8,8 @@ from ecmean.global_mean import global_mean
 from ecmean.libs.ncfixers import xr_preproc
 from ecmean.libs.general import are_dicts_equal
 
-# set tolerance
-tolerance = 1e-3
+# set TOLERANCE
+TOLERANCE = 1e-3
 
 # set up coverage env var
 env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
@@ -22,7 +22,7 @@ def load_gm_txt_files(textfile):
     """
 
     data_dict = {}
-    with open(textfile, 'r') as file:
+    with open(textfile, 'r', encoding='utf8') as file:
         # Read the file line by line
         for line in file:
             # Remove leading and trailing whitespace and split the line by '|'
@@ -52,7 +52,7 @@ def test_cmd_global_mean_coupled():
     data1 = load_gm_txt_files(file1)
     data2 = load_gm_txt_files(file2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
 
 
 # call on amip ECE
@@ -67,7 +67,7 @@ def test_global_mean_amip():
     data1 = load_gm_txt_files(file1)
     data2 = load_gm_txt_files(file2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
 
 # call on amip ECE using the xdataset option
 def test_global_mean_amip_xdataset():
@@ -77,12 +77,11 @@ def test_global_mean_amip_xdataset():
         os.remove(file1)
     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
     global_mean(exp='amip', year1=1990, year2=1990, numproc=4, config='tests/config.yml',
-                xdataset=xfield)
-    
+                xdataset=xfield)   
     data1 = load_gm_txt_files(file1)
     data2 = load_gm_txt_files(file2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
 
 
 # call on historical CMIP6
@@ -96,5 +95,5 @@ def test_global_mean_CMIP6():
     data1 = load_gm_txt_files(file1)
     data2 = load_gm_txt_files(file2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "TXT files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
 

--- a/tests/test_performance_indices.py
+++ b/tests/test_performance_indices.py
@@ -4,12 +4,15 @@
 # all run for both EC23 and RK08 climatologies
 import os
 import subprocess
-from filecmp import cmp
 import pytest
 import xarray as xr
+import yaml
 from ecmean.performance_indices import performance_indices
 from ecmean.libs.ncfixers import xr_preproc
-#from ecmean.libs.general import set_multiprocessing_start_method
+from ecmean.libs.general import are_dicts_equal
+
+# set tolerance
+tolerance = 1e-4
 
 # set up coverage env var
 env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
@@ -19,16 +22,26 @@ env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
 def test_performance_indices_cpld(clim):
 
     performance_indices('cpld', 1990, 1990, numproc=4, climatology=clim, config='tests/config.yml')
-    assert cmp('tests/table/PI4_' + clim + '_cpld_EC-Earth4_r1i1p1f1_1990_1990.yml',
-               'tests/table/PI4_' + clim + '_cpld_1990_1990.ref')
+    file1 = 'tests/table/PI4_' + clim + '_cpld_EC-Earth4_r1i1p1f1_1990_1990.yml'
+    file2 = 'tests/table/PI4_' + clim + '_cpld_1990_1990.ref'
+    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+        data1 = yaml.safe_load(f1)
+        data2 = yaml.safe_load(f2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+
 
 # test on amip
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
 def test_performance_indices_amip(clim):
     performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='pluto')
+    file1 = 'pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
+    file2 = 'tests/table/PI4_' + clim + '_amip_1990_1990.ref'
+    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+        data1 = yaml.safe_load(f1)
+        data2 = yaml.safe_load(f2)
 
-    assert cmp('pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml',
-               'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
+    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
 
 # test performance_indices from commnand line + debug
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
@@ -36,24 +49,64 @@ def test_cmd_performance_indices_CMIP6(clim):
     subprocess.run(['performance_indices', 'historical', '1990', '1990', '-j', '2', '-c',
                    'tests/config_CMIP6.yml', '-k', clim, '-m', 'EC-Earth3', '-v', 'debug'],
                     env=env, check=True)
-    assert cmp('tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml',
-               'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref')
+    file1 = 'tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml'
+    file2 = 'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref'
+    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+        data1 = yaml.safe_load(f1)
+        data2 = yaml.safe_load(f2)
+
+    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
 
 # test on amip but with access from xarray dataset
-
-
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
 def test_performance_indices_amip_xdataset(clim):
-    thefile = 'tests/table/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
-    if os.path.isfile(thefile):
-        os.remove(thefile)
+    file1 = 'tests/table/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
+    file2 = 'tests/table/PI4_' + clim + '_amip_1990_1990.ref'
+    if os.path.isfile(file1):
+        os.remove(file1)
     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
     performance_indices('amip', 1990, 1990, numproc=2, climatology=clim,
                         config='tests/config.yml', xdataset=xfield)
-    assert cmp(thefile, 'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
+    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+        data1 = yaml.safe_load(f1)
+        data2 = yaml.safe_load(f2)
 
+    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+
+
+# #test on coupled
 # @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
-# def test_performance_indices_CMIP6(clim):
-#    performance_indices('historical', 1990, 1990, numproc = 2, climatology = clim, config = 'tests/config_CMIP6.yml')
-#    assert cmp('tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml',
-#               'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref')
+# def test_performance_indices_cpld_old(clim):
+
+#     performance_indices('cpld', 1990, 1990, numproc=4, climatology=clim, config='tests/config.yml')
+#     assert cmp('tests/table/PI4_' + clim + '_cpld_EC-Earth4_r1i1p1f1_1990_1990.yml',
+#                'tests/table/PI4_' + clim + '_cpld_1990_1990.ref')
+
+# # test on amip
+# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
+# def test_performance_indices_amip(clim):
+#     performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='pluto')
+
+#     assert cmp('pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml',
+#                'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
+
+# # test performance_indices from commnand line + debug
+# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
+# def test_cmd_performance_indices_CMIP6(clim):
+#     subprocess.run(['performance_indices', 'historical', '1990', '1990', '-j', '2', '-c',
+#                    'tests/config_CMIP6.yml', '-k', clim, '-m', 'EC-Earth3', '-v', 'debug'],
+#                     env=env, check=True)
+#     assert cmp('tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml',
+#                'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref')
+
+# # test on amip but with access from xarray dataset
+# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
+# def test_performance_indices_amip_xdataset(clim):
+#     thefile = 'tests/table/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
+#     if os.path.isfile(thefile):
+#         os.remove(thefile)
+#     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
+#     performance_indices('amip', 1990, 1990, numproc=2, climatology=clim,
+#                         config='tests/config.yml', xdataset=xfield)
+#     assert cmp(thefile, 'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
+

--- a/tests/test_performance_indices.py
+++ b/tests/test_performance_indices.py
@@ -12,7 +12,7 @@ from ecmean.libs.ncfixers import xr_preproc
 from ecmean.libs.general import are_dicts_equal
 
 # set tolerance
-tolerance = 1e-4
+tolerance = 1e-3
 
 # set up coverage env var
 env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
@@ -34,8 +34,8 @@ def test_performance_indices_cpld(clim):
 # test on amip
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
 def test_performance_indices_amip(clim):
-    performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='pluto')
-    file1 = 'pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
+    performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='tests/pluto')
+    file1 = 'tests/pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
     file2 = 'tests/table/PI4_' + clim + '_amip_1990_1990.ref'
     with open(file1, 'r') as f1, open(file2, 'r') as f2:
         data1 = yaml.safe_load(f1)

--- a/tests/test_performance_indices.py
+++ b/tests/test_performance_indices.py
@@ -11,8 +11,8 @@ from ecmean.performance_indices import performance_indices
 from ecmean.libs.ncfixers import xr_preproc
 from ecmean.libs.general import are_dicts_equal
 
-# set tolerance
-tolerance = 1e-3
+# set TOLERANCE
+TOLERANCE = 1e-3
 
 # set up coverage env var
 env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
@@ -20,15 +20,14 @@ env = {**os.environ, "COVERAGE_PROCESS_START": ".coveragerc"}
 # test on coupled
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
 def test_performance_indices_cpld(clim):
-
     performance_indices('cpld', 1990, 1990, numproc=4, climatology=clim, config='tests/config.yml')
     file1 = 'tests/table/PI4_' + clim + '_cpld_EC-Earth4_r1i1p1f1_1990_1990.yml'
     file2 = 'tests/table/PI4_' + clim + '_cpld_1990_1990.ref'
-    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+    with open(file1, 'r', encoding='utf8') as f1, open(file2, 'r', encoding='utf8') as f2:
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
 
 
 # test on amip
@@ -37,11 +36,11 @@ def test_performance_indices_amip(clim):
     performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='tests/pluto')
     file1 = 'tests/pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
     file2 = 'tests/table/PI4_' + clim + '_amip_1990_1990.ref'
-    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+    with open(file1, 'r', encoding='utf8') as f1, open(file2, 'r', encoding='utf8') as f2:
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
 
 # test performance_indices from commnand line + debug
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
@@ -51,11 +50,11 @@ def test_cmd_performance_indices_CMIP6(clim):
                     env=env, check=True)
     file1 = 'tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml'
     file2 = 'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref'
-    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+    with open(file1, 'r', encoding='utf8') as f1, open(file2, 'r', encoding='utf8') as f2:
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
 
 # test on amip but with access from xarray dataset
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
@@ -67,46 +66,11 @@ def test_performance_indices_amip_xdataset(clim):
     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
     performance_indices('amip', 1990, 1990, numproc=2, climatology=clim,
                         config='tests/config.yml', xdataset=xfield)
-    with open(file1, 'r') as f1, open(file2, 'r') as f2:
+    with open(file1, 'r', encoding='utf8') as f1, open(file2, 'r', encoding='utf8') as f2:
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, tolerance), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
 
 
-# #test on coupled
-# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
-# def test_performance_indices_cpld_old(clim):
-
-#     performance_indices('cpld', 1990, 1990, numproc=4, climatology=clim, config='tests/config.yml')
-#     assert cmp('tests/table/PI4_' + clim + '_cpld_EC-Earth4_r1i1p1f1_1990_1990.yml',
-#                'tests/table/PI4_' + clim + '_cpld_1990_1990.ref')
-
-# # test on amip
-# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
-# def test_performance_indices_amip(clim):
-#     performance_indices('amip', 1990, 1990, numproc=1, climatology=clim, config='tests/config.yml', outputdir='pluto')
-
-#     assert cmp('pluto/YAML/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml',
-#                'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
-
-# # test performance_indices from commnand line + debug
-# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
-# def test_cmd_performance_indices_CMIP6(clim):
-#     subprocess.run(['performance_indices', 'historical', '1990', '1990', '-j', '2', '-c',
-#                    'tests/config_CMIP6.yml', '-k', clim, '-m', 'EC-Earth3', '-v', 'debug'],
-#                     env=env, check=True)
-#     assert cmp('tests/table/PI4_' + clim + '_historical_EC-Earth3_r1i1p1f1_1990_1990.yml',
-#                'tests/table/PI4_' + clim + '_CMIP6_1990_1990.ref')
-
-# # test on amip but with access from xarray dataset
-# @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
-# def test_performance_indices_amip_xdataset(clim):
-#     thefile = 'tests/table/PI4_' + clim + '_amip_EC-Earth4_r1i1p1f1_1990_1990.yml'
-#     if os.path.isfile(thefile):
-#         os.remove(thefile)
-#     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
-#     performance_indices('amip', 1990, 1990, numproc=2, climatology=clim,
-#                         config='tests/config.yml', xdataset=xfield)
-#     assert cmp(thefile, 'tests/table/PI4_' + clim + '_amip_1990_1990.ref')
 


### PR DESCRIPTION
So digging into the problem of #92 it has been found that it is enough to load the masks before the interpolation is carried out. However, some small changes in some backend part of this tool changed the output of the interpolation of PIs, leading to test failures. We thus changed the approach of the tests, no longer comparing the single file but loading the yaml files and operating an element-wise recursive comparison developed by a brilliant AI. 

Results are satisfying, if tests are passed I am going to extend this to `global_mean` and set this in a new release. 