### PR TITLE
Expand using first year for grdfile and areafile

### DIFF
--- a/ecmean/libs/files.py
+++ b/ecmean/libs/files.py
@@ -147,13 +147,15 @@ def get_inifiles(face, diag):
                         Path(face['model']['basedir']) / \
                         Path(inifile)
 
-                ifiles[comp][name] = str(_expand_filename(inifile, '', diag))
-                loggy.info('%s for component %s is: %s', name, comp, ifiles[comp][name])
-
-                # safe check if inifile exist
-                if not glob(ifiles[comp][name]):
-                    loggy.warning('Inifile %s cannot be found!', ifiles[comp][name])
+                expandfile = _expand_filename(inifile, '', diag)
+                filenames = glob(str(expandfile))
+                if not filenames:
+                    loggy.warning('Inifile %s cannot be found!', str(expandfile))
                     ifiles[comp][name] = ''
+                else:
+                    ifiles[comp][name] = str(_filter_filename_by_year(str(inifile), filenames, diag.year1)[0])
+
+                loggy.info('%s for component %s is: %s', name, comp, ifiles[comp][name])
 
             else:
                 ifiles[comp][name] = ''


### PR DESCRIPTION
This addresses the issue discussed in #99 by which in some cases ECMean4 does not run because still incomplete files are used as area or grid files.

Close #99 