### PR TITLE
Allow for configuration file from dictionary and not from file only

### DIFF
--- a/ecmean/libs/diagnostic.py
+++ b/ecmean/libs/diagnostic.py
@@ -68,15 +68,14 @@ class Diagnostic():
         # Various raise and input and output directories
         if not cfg['dirs']['exp']:
             raise ValueError('No experiment directory defined in config file')
-        if not cfg['dirs']['tab']:
-            raise ValueError('No table directory defined in config file')
-        if not cfg['dirs']['fig']:
-            raise ValueError('No figure directory defined in config file')
-        
         self.ecedir = Path(os.path.expandvars(cfg['dirs']['exp']))
         outputdir = getattr(args, 'outputdir', None)
         if outputdir is None:
+            if not cfg['dirs']['tab']:
+                raise ValueError('No table directory defined in config file')
             self.tabdir = Path(os.path.expandvars(cfg['dirs']['tab']))
+            if not cfg['dirs']['fig']:
+                raise ValueError('No figure directory defined in config file')
             self.figdir = Path(os.path.expandvars(cfg['dirs']['fig']))
         else:
             self.tabdir = Path(os.path.join(outputdir, 'YAML'))
@@ -91,10 +90,10 @@ class Diagnostic():
             self.cfg_performance_indices(cfg)
 
         # setting up interface file
-        self.interface = getattr(args, 'interface', cfg['interface'])
+        self.interface = getattr(args, 'interface', None) or cfg['interface']
 
         # setting up model name
-        self.modelname = getattr(args, 'modelname', cfg['model']['name'])
+        self.modelname = getattr(args, 'modelname', None) or cfg['model']['name']
 
         # allow for both interface name or interface file
         if not os.path.exists(self.interface):

--- a/tests/test_global_mean.py
+++ b/tests/test_global_mean.py
@@ -6,6 +6,7 @@ import xarray as xr
 from ecmean.global_mean import global_mean
 from ecmean.libs.ncfixers import xr_preproc
 from ecmean.libs.general import are_dicts_equal
+from ecmean.libs.files import load_yaml
 
 # set TOLERANCE
 TOLERANCE = 1e-3
@@ -26,13 +27,11 @@ def load_gm_txt_files(textfile):
         for line in file:
             # Remove leading and trailing whitespace and split the line by '|'
             columns = line.strip().split('|')
-            
             # Check if there are at least 5 columns (including the header row)
             if len(columns) >= 5:
                 # Extract the first and fourth columns and remove leading/trailing whitespace
                 variable = columns[1].strip()
                 value = columns[4].strip()
-                
                 # Add the data to the dictionary if it's not empty
                 if variable and value:
                     data_dict[variable] = value
@@ -69,19 +68,19 @@ def test_global_mean_amip():
     assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
 
 # call on amip ECE using the xdataset option
-def test_global_mean_amip_xdataset():
+def test_global_mean_amip_xdataset_config_dict():
     file1 = 'tests/table/global_mean_amip_EC-Earth4_r1i1p1f1_1990_1990.txt'
     file2 = 'tests/table/global_mean_amip_1990_1990.ref'
     if os.path.isfile(file1):
         os.remove(file1)
     xfield = xr.open_mfdataset('tests/data/amip/output/oifs/*.nc', preprocess=xr_preproc)
-    global_mean(exp='amip', year1=1990, year2=1990, numproc=4, config='tests/config.yml',
-                xdataset=xfield)   
+    config = load_yaml('tests/config.yml')
+    global_mean(exp='amip', year1=1990, year2=1990, numproc=4, config=config,
+                xdataset=xfield)
     data1 = load_gm_txt_files(file1)
     data2 = load_gm_txt_files(file2)
 
     assert are_dicts_equal(data1, data2, TOLERANCE), "TXT files are not identical."
-
 
 # call on historical CMIP6
 def test_global_mean_CMIP6():

--- a/tests/test_performance_indices.py
+++ b/tests/test_performance_indices.py
@@ -27,7 +27,7 @@ def test_performance_indices_cpld(clim):
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), f"YAML files are not identical.\nData1: {data1}\nData2: {data2}"
 
 
 # test on amip
@@ -40,7 +40,7 @@ def test_performance_indices_amip(clim):
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE), f"YAML files are not identical.\nData1: {data1}\nData2: {data2}"
 
 # test performance_indices from commnand line + debug
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
@@ -54,8 +54,7 @@ def test_cmd_performance_indices_CMIP6(clim):
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
-
+    assert are_dicts_equal(data1, data2, TOLERANCE), f"YAML files are not identical.\nData1: {data1}\nData2: {data2}"
 # test on amip but with access from xarray dataset
 @pytest.mark.parametrize("clim", ['RK08', 'EC23'])
 def test_performance_indices_amip_xdataset(clim):
@@ -70,7 +69,7 @@ def test_performance_indices_amip_xdataset(clim):
         data1 = yaml.safe_load(f1)
         data2 = yaml.safe_load(f2)
 
-    assert are_dicts_equal(data1, data2, TOLERANCE), "YAML files are not identical."
+    assert are_dicts_equal(data1, data2, TOLERANCE),f"YAML files are not identical.\nData1: {data1}\nData2: {data2}"
 
 
 


### PR DESCRIPTION
Update the `Diagnostics` class to have configuration file read by a dictionary also, not only from yaml